### PR TITLE
Fix issue with sample test case

### DIFF
--- a/tests/UsedClassesAvailableTest.php
+++ b/tests/UsedClassesAvailableTest.php
@@ -17,7 +17,10 @@ class UsedClassesAvailableTest extends TestCase
         $pluginClasses = $this->getPluginClasses();
 
         foreach ($pluginClasses as $class) {
-            $classRelativePath = str_replace(['.php', '/'], ['', '\\'], $class->getRelativePathname());
+            $path = explode(DIRECTORY_SEPARATOR, $class->getRelativePathname());
+            unset($path[0]); // src folder
+
+            $classRelativePath = str_replace(['.php', '/'], ['', '\\'], implode(DIRECTORY_SEPARATOR, $path));
 
             if (class_exists($namespace . '\\' . $classRelativePath)) {
                 $counter += 1;

--- a/tests/UsedClassesAvailableTest.php
+++ b/tests/UsedClassesAvailableTest.php
@@ -13,24 +13,26 @@ class UsedClassesAvailableTest extends TestCase
     public function testClassesAreInstantiable(): void
     {
         $namespace = str_replace('Tests', '', __NAMESPACE__);
+        $counter = 0;
+        $pluginClasses = $this->getPluginClasses();
 
-        foreach ($this->getPluginClasses() as $class) {
+        foreach ($pluginClasses as $class) {
             $classRelativePath = str_replace(['.php', '/'], ['', '\\'], $class->getRelativePathname());
 
-            $this->getMockBuilder($namespace . '\\' . $classRelativePath)
-                ->disableOriginalConstructor()
-                ->getMock();
+            if (class_exists($namespace . '\\' . $classRelativePath)) {
+                $counter += 1;
+            }
         }
 
-        // Nothing broke so far, classes seem to be instantiable
-        $this->assertTrue(true);
+        $this->assertEquals(count($pluginClasses), $counter, "$counter classes loaded");
     }
 
     private function getPluginClasses(): Finder
     {
         $finder = new Finder();
         $finder->in(realpath(__DIR__ . '/../'));
-        $finder->exclude('Test');
+        $finder->ignoreUnreadableDirs();
+        $finder->exclude(['tests', 'vendor']);
         return $finder->files()->name('*.php');
     }
 }


### PR DESCRIPTION
Using the mock builder to validate the existence of the class doesn't work. In the current setting, the following code succeeds just as well:

```php
<?php
$this->getMockBuilder('RandomClassThatDoesNotExist')->getMock();
```

This changes will ensure that the bootstrap actually loads the classes properly by counting the number of classes that match the specification and comparing against the number of files found with the Finder component.
